### PR TITLE
(SIMP-1164) Fixed issue with ordering in job.erb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 .yardoc
 dist
 /pkg
-/spec/fixtures
-/spec/rp_env
-!/spec/hieradata/default.yaml
+/spec/fixtures/*
 !/spec/fixtures/site.pp
 /.rspec_system
 /.vagrant

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jul 29 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.2-0
+- Fixed an ordering issue in the 'job' ERB template
+
 * Tue Mar 01 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.1.0-5
 - Added compliance function support
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-upstart",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author":  "simp",
   "summary": "A SIMP puppet module for managing upstart",
   "license": "Apache-2.0",

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -32,7 +32,7 @@
 #
 
 <%
-  t_process_types.keys.each do |t_var_name|
+  t_process_types.keys.sort.each do |t_var_name|
     unless eval("@#{t_var_name}").eql?('nil')
 
       if eval("@#{t_var_name}_type") == 'exec'


### PR DESCRIPTION
The keys to the hash passed into job.erb needed to be ordered so that
Ruby 1.8 did not flip them constantly.

SIMP-1164 #comment Fix ordering issue in job.erb