### PR TITLE
(SIMP-2436) Removed ctrl-alt-del job

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Jan 05 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
+- Removed the 'ctrl-alt-del' job since that has been moved into the 'simp'
+  module
+
 * Thu Dec 15 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0-0
 - Use simp_options module for global catalysts
 - Use strongly typed parameters

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,28 +1,22 @@
-# This class allows you to configure the upstart init files.
+# This class allows you to configure the upstart init files
 #
 # Unless otherwise noted, the variables passed to this class set up
-# /etc/sysconfig/init
+# ``/etc/sysconfig/init``
 #
 # This *only* sets security-relevant options. You'll need to use the augeas
 # provider to prod different values in the target file but this provides a good
 # example.
 #
-# See init(8) for more information.
+# @see init(8)
 #
 # @param auditd
 #   If true, includes SIMP's ::auditd class and then adds upstart audit rule
 #
-# @param disable_ctrl_alt_del
-#   If true, do not restart the system when ctrl-alt-del is pressed. Instead,
-#   log the keypress to the system log at level local6.warning.
-#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class upstart (
-  Boolean $auditd               = simplib::lookup('simp_options::auditd', { 'default_value' => false }),
-  Boolean $disable_ctrl_alt_del = true
+  Boolean $auditd               = simplib::lookup('simp_options::auditd', { 'default_value' => false })
 ) {
-
   if $auditd {
     include '::auditd'
     auditd::add_rules { 'upstart':
@@ -36,13 +30,4 @@ class upstart (
     group  => 'root',
     mode   => '0644'
   }
-
-  if $disable_ctrl_alt_del {
-    upstart::job { 'control-alt-delete':
-      main_process => '/bin/logger -p local6.warning "Ctrl-Alt-Del was pressed"',
-      start_on     => 'control-alt-delete',
-      description  => 'Logs that Ctrl-Alt-Del was pressed without rebooting the system.'
-    }
-  }
-
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -36,14 +36,6 @@ describe 'upstart' do
               'mode' => '0644'
             })
           end
-
-          it do
-            is_expected.to contain_upstart__job('control-alt-delete').with({
-              'main_process' => '/bin/logger -p local6.warning "Ctrl-Alt-Del was pressed"',
-              'start_on'     => 'control-alt-delete',
-              'description'  => 'Logs that Ctrl-Alt-Del was pressed without rebooting the system.'
-            })
-          end
         end
 
         context 'with auditing enabled' do
@@ -54,12 +46,6 @@ describe 'upstart' do
               'content' => '-w /etc/init/ -p wa -k CFG_upstart'
             })
           end
-        end
-
-        context 'with disable_ctrl_alt_del false' do
-          let(:params) {{ :disable_ctrl_alt_del => false }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to_not contain_upstart__job('control-alt-delete') }
         end
       end
     end


### PR DESCRIPTION
The ctrl-alt-del job has been moved into the 'simp' module for
consolidation of this functionality across the different init systems.

SIMP-2436 #comment remove conflicting job from upstart