### PR TITLE
(SIMP-6103) Replace OBE validate_umask() with Simplib::Umask

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
 #-----------------------------------------------------------------------
 
 .pup_4: &pup_4
-  image: 'ruby:2.4'
+  image: 'ruby:2.1'
   variables:
     PUPPET_VERSION: '~> 4.0'
     MATRIX_RUBY_VERSION: '2.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
+- Use Simplib::Umask data type in lieu of validate_umask(),
+  a deprecated simplib Puppet 3 function.
+
 * Thu Sep 13 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.0.3-0
 - Added Puppet 5 and OEL support
 - Dropped support for Hiera v4.  Dependency auditd has dropped support

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -113,7 +113,7 @@ define upstart::job (
     Optional[String]                $doc_version       = undef,
     Optional[Array[String]]         $emits             = undef,
     Optional[Upstart::Console]      $console           = undef,
-    String                          $umask             = '022',
+    Simplib::Umask                  $umask             = '022',
     Optional[Integer]               $nice              = undef,
     Optional[String]                $oom               = undef,
     Optional[Stdlib::Absolutepath]  $chroot            = undef,
@@ -125,7 +125,6 @@ define upstart::job (
     Boolean                         $expect_fork       = false
 ) {
 
-  validate_umask($umask)
   if $sys_limit {
     upstart::validate_sys_limit($sys_limit)
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-upstart",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing upstart",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Use Simplib::Umask data type in lieu of validate_umask(),
a deprecated simplib Puppet 3 function.

SIMP-6103 #comment pupmod-simp-upstart