### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
 - Use Simplib::Umask data type in lieu of validate_umask(),
   a deprecated simplib Puppet 3 function.
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
 
 * Thu Sep 13 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 6.0.3-0
 - Added Puppet 5 and OEL support

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Linux-compatible distribution.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 If you find any issues, they can be submitted to our
 [JIRA](https://simp-project.atlassian.net).

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-upstart